### PR TITLE
Fixed deep copy using more robust implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 				"axios": "^1.6.0",
 				"bulma": "^0.9.4",
 				"d3": "^7.9.0",
+				"deep-copy-ts": "^0.5.4",
 				"dompurify": "^3.1.2",
 				"dotenv": "^16.3.1",
 				"kioskboard": "^2.3.0",
@@ -2635,6 +2636,12 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/deep-copy-ts": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/deep-copy-ts/-/deep-copy-ts-0.5.4.tgz",
+			"integrity": "sha512-YJbPjw0YqdosorpCsa6copy1p/gJsFT9Q6Zq0tLi7D0nXh6Y/usjeIQZfkzV3HVuqY0Hl/5gM7TwgIbIWvEjlA==",
+			"license": "MIT"
 		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"axios": "^1.6.0",
 		"bulma": "^0.9.4",
 		"d3": "^7.9.0",
+		"deep-copy-ts": "^0.5.4",
 		"dompurify": "^3.1.2",
 		"dotenv": "^16.3.1",
 		"kioskboard": "^2.3.0",

--- a/src/lib/components/UIContent.svelte
+++ b/src/lib/components/UIContent.svelte
@@ -8,7 +8,8 @@
     backgroundImageAndSoundStore,
     sessionIdStore,
   } from "$lib/store";
-  import { deepCopy, toBase64 } from "$lib/util";
+  import { deepCopy } from "deep-copy-ts";
+  import { toBase64 } from "$lib/util";
   import { type PlatformAppDto, type TextUIContentDto } from "@sermas/toolkit";
   import type {
     ChatMessage,
@@ -151,9 +152,11 @@
 
       showHomepage = false;
 
+      console.warn("chatHistory", chatHistory);
+
       history = [...deepCopy(chatHistory)];
 
-      // console.warn("history", history);
+      console.warn("history", history);
 
       if (history.length) {
         lastMessage = history[history.length - 1];

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -53,7 +53,3 @@ export const toBase64 = (blob: Blob): Promise<string> => {
     };
   });
 };
-
-export const deepCopy = <T>(obj: T): T => {
-  return JSON.parse(JSON.stringify(obj));
-}


### PR DESCRIPTION
JSON-based deep copy fails on Date objects. This package is more robust.
Maybe it should be replaced everywhere.