### PR TITLE
Fix: handling undefined sessionId

### DIFF
--- a/src/routes/[appId]/+layout.svelte
+++ b/src/routes/[appId]/+layout.svelte
@@ -100,10 +100,11 @@
   };
 
   const onSessionStatusChanged = (ev: SessionStatusEvent) => {
-    if (toolkit?.getSessionId() !== ev.sessionId) return;
+    const toolkitSessionId = toolkit?.getSessionId();
+    if (toolkitSessionId !== undefined && toolkitSessionId !== ev.sessionId) return;
     if (ev.status !== "closed") return;
     logger.log(`Session closed, reloading page`);
-    document?.location?.reload();
+    window?.location?.reload();
   };
 
   onMount(async () => {

--- a/src/routes/[appId]/+layout.svelte
+++ b/src/routes/[appId]/+layout.svelte
@@ -103,8 +103,11 @@
     const toolkitSessionId = toolkit?.getSessionId();
     if (toolkitSessionId !== undefined && toolkitSessionId !== ev.sessionId) return;
     if (ev.status !== "closed") return;
-    logger.log(`Session closed, reloading page`);
-    window?.location?.reload();
+    const settings = toolkit.getSettings()?.get();
+    if (settings?.interactionStart === 'on-load') {
+      logger.log(`Session closed, reloading page`);
+      window?.location?.reload();
+    }
   };
 
   onMount(async () => {


### PR DESCRIPTION
If the toolkit sessionId is undefined, the event still passes through.